### PR TITLE
26 use runtime managed erc20 tokens in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@ Alternatively you can use the parameter `local` instead of `foucoco`. This expec
 ```
 brew install binaryen
 ```
+

--- a/nabla/config.json
+++ b/nabla/config.json
@@ -1,5 +1,8 @@
 {
   "contracts": {
+    "TestableERC20Wrapper": {
+      "path": "contracts/TestableERC20Wrapper.sol"
+    },
     "Router": {
       "repository": "nablaContracts",
       "path": "contracts/src/core/Router.sol"
@@ -50,7 +53,10 @@
       "git": "https://github.com/0xamberhq/contracts.git",
       "branch": "feature/backstop-pool-coverage-ratio",
       "init": "yarn",
-      "importpaths": ["contracts/@chain/pendulum", "node_modules"]
+      "importpaths": [
+        "contracts/@chain/pendulum",
+        "node_modules"
+      ]
     },
     "pendulumWrappers": {
       "git": "https://github.com/pendulum-chain/pendulum-ink-wrapper",
@@ -89,8 +95,8 @@
   "buildFolder": "../target",
   "limits": {
     "gas": {
-      "refTime": "100000000000",
-      "proofSize": "10000000"
+      "refTime": "10000000000000000",
+      "proofSize": "10000000000000000"
     },
     "storageDeposit": "10000000000000"
   }

--- a/nabla/config.json
+++ b/nabla/config.json
@@ -1,7 +1,7 @@
 {
   "contracts": {
     "TestableERC20Wrapper": {
-      "path": "contracts/TestableERC20Wrapper.sol"
+      "path": "testable-erc20-wrapper/TestableERC20Wrapper.sol"
     },
     "Router": {
       "repository": "nablaContracts",

--- a/nabla/config.json
+++ b/nabla/config.json
@@ -1,6 +1,7 @@
 {
   "contracts": {
     "TestableERC20Wrapper": {
+      "repository": "pendulumWrappers",
       "path": "testable-erc20-wrapper/TestableERC20Wrapper.sol"
     },
     "Router": {
@@ -60,7 +61,7 @@
     },
     "pendulumWrappers": {
       "git": "https://github.com/pendulum-chain/pendulum-ink-wrapper",
-      "branch": "32-support-latest-solang-version"
+      "branch": "master"
     }
   },
   "networks": {

--- a/nabla/test/TestableERC20Tests.ts
+++ b/nabla/test/TestableERC20Tests.ts
@@ -30,10 +30,8 @@ export default async function (environment: TestSuiteEnvironment) {
     const assetNative = await newTestableERC20Wrapper("TestNative", "TEST1", 12, [0], [0], [], []);
     const token1 = await newTestableERC20Wrapper("TestNonNative", "TEST2", 12, [1], [1], [], []);
 
-
     const MINT_AMOUNT = unit(10000);
     const BURN_AMOUNT = unit(10);
-
 
     return {
         async setUp() {
@@ -75,8 +73,5 @@ export default async function (environment: TestSuiteEnvironment) {
 
             assertEq(totalSupplyBef - totalSupplyAft, BURN_AMOUNT);
         },
-
-
-
     };
 }

--- a/nabla/test/TestableERC20Tests.ts
+++ b/nabla/test/TestableERC20Tests.ts
@@ -22,21 +22,13 @@ export default async function (environment: TestSuiteEnvironment) {
         },
     } = environment;
 
-    function assertApproxEq(a: bigint, b: bigint, errorMessage: string): void {
-        if (a !== 0n && b !== 0n) {
-            assertApproxEqRel(a, b, 5n * 10n ** 15n, errorMessage);
-        } else {
-            assertApproxEqAbs(a, b, milliUnit(5), errorMessage);
-        }
-    }
-
     let router: TestContract;
     let backstop: TestContract;
     let swapPool1: TestContract;
     let swapPool2: TestContract;
 
-    const asset1 = await newTestableERC20Wrapper("TestNative", "TEST1", 12, [0], [0], [], []);
-    const asset2 = await newTestableERC20Wrapper("TestNonNative", "TEST2", 12, [1], [1], [], []);
+    const assetNative = await newTestableERC20Wrapper("TestNative", "TEST1", 12, [0], [0], [], []);
+    const token1 = await newTestableERC20Wrapper("TestNonNative", "TEST2", 12, [1], [1], [], []);
 
 
     const MINT_AMOUNT = unit(10000);
@@ -48,38 +40,38 @@ export default async function (environment: TestSuiteEnvironment) {
 
         },
         async testMintsNative() {
-            let totalSupplyBef = await asset1.totalSupply();
-            await asset1.mint(BOB, MINT_AMOUNT);
-            let totalSupplyAft = await asset1.totalSupply();
+            let totalSupplyBef = await assetNative.totalSupply();
+            await assetNative.mint(BOB, MINT_AMOUNT);
+            let totalSupplyAft = await assetNative.totalSupply();
 
             assertEq(totalSupplyAft - totalSupplyBef, MINT_AMOUNT);
         },
 
         async testMintsTokensPallet() {
-            let totalSupplyBef = await asset2.totalSupply();
-            let balanceBobBef = await asset2.balanceOf(BOB);
+            let totalSupplyBef = await token1.totalSupply();
+            let balanceBobBef = await token1.balanceOf(BOB);
 
-            await asset2.mint(BOB, MINT_AMOUNT);
+            await token1.mint(BOB, MINT_AMOUNT);
 
-            let totalSupplyAft = await asset2.totalSupply();
-            let balanceBob = await asset2.balanceOf(BOB);
+            let totalSupplyAft = await token1.totalSupply();
+            let balanceBob = await token1.balanceOf(BOB);
 
             assertEq(totalSupplyAft - totalSupplyBef, MINT_AMOUNT);
             assertEq(balanceBob - balanceBobBef, MINT_AMOUNT);
         },
 
         async testBurnsNative() {
-            let totalSupplyBef = await asset1.totalSupply();
-            await asset1.burn(BOB, BURN_AMOUNT);
-            let totalSupplyAft = await asset1.totalSupply();
+            let totalSupplyBef = await assetNative.totalSupply();
+            await assetNative.burn(BOB, BURN_AMOUNT);
+            let totalSupplyAft = await assetNative.totalSupply();
 
             assertEq(totalSupplyBef - totalSupplyAft, BURN_AMOUNT);
         },
 
         async testBurnsToken() {
-            let totalSupplyBef = await asset2.totalSupply();
-            await asset2.burn(BOB, BURN_AMOUNT);
-            let totalSupplyAft = await asset2.totalSupply();
+            let totalSupplyBef = await token1.totalSupply();
+            await token1.burn(BOB, BURN_AMOUNT);
+            let totalSupplyAft = await token1.totalSupply();
 
             assertEq(totalSupplyBef - totalSupplyAft, BURN_AMOUNT);
         },

--- a/nabla/test/TestableERC20Tests.ts
+++ b/nabla/test/TestableERC20Tests.ts
@@ -1,0 +1,90 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+
+import { TestContract, TestSuiteEnvironment } from "../../src/index";
+import { assertApproxEqAbs, assertApproxEqRel, assertEq, assertGt, assertLt, e } from "../../src/index";
+
+const MAX_UINT256 = 2n ** 256n - 1n;
+
+const BOB = "6k6gXPB9idebCxqSJuqpjPaqfYLQbdLHhvsANH8Dg8GQN3tT";
+
+export default async function (environment: TestSuiteEnvironment) {
+    const {
+        address,
+        unit,
+        milliUnit,
+        microUnit,
+        getContractByAddress,
+        vm,
+        tester,
+        constructors: {
+            newTestableERC20Wrapper,
+        },
+    } = environment;
+
+    function assertApproxEq(a: bigint, b: bigint, errorMessage: string): void {
+        if (a !== 0n && b !== 0n) {
+            assertApproxEqRel(a, b, 5n * 10n ** 15n, errorMessage);
+        } else {
+            assertApproxEqAbs(a, b, milliUnit(5), errorMessage);
+        }
+    }
+
+    let router: TestContract;
+    let backstop: TestContract;
+    let swapPool1: TestContract;
+    let swapPool2: TestContract;
+
+    const asset1 = await newTestableERC20Wrapper("TestNative", "TEST1", 12, [0], [0], [], []);
+    const asset2 = await newTestableERC20Wrapper("TestNonNative", "TEST2", 12, [1], [1], [], []);
+
+
+    const MINT_AMOUNT = unit(10000);
+    const BURN_AMOUNT = unit(10);
+
+
+    return {
+        async setUp() {
+
+        },
+        async testMintsNative() {
+            let totalSupplyBef = await asset1.totalSupply();
+            await asset1.mint(BOB, MINT_AMOUNT);
+            let totalSupplyAft = await asset1.totalSupply();
+
+            assertEq(totalSupplyAft - totalSupplyBef, MINT_AMOUNT);
+        },
+
+        async testMintsTokensPallet() {
+            let totalSupplyBef = await asset2.totalSupply();
+            let balanceBobBef = await asset2.balanceOf(BOB);
+
+            await asset2.mint(BOB, MINT_AMOUNT);
+
+            let totalSupplyAft = await asset2.totalSupply();
+            let balanceBob = await asset2.balanceOf(BOB);
+
+            assertEq(totalSupplyAft - totalSupplyBef, MINT_AMOUNT);
+            assertEq(balanceBob - balanceBobBef, MINT_AMOUNT);
+        },
+
+        async testBurnsNative() {
+            let totalSupplyBef = await asset1.totalSupply();
+            await asset1.burn(BOB, BURN_AMOUNT);
+            let totalSupplyAft = await asset1.totalSupply();
+
+            assertEq(totalSupplyBef - totalSupplyAft, BURN_AMOUNT);
+        },
+
+        async testBurnsToken() {
+            let totalSupplyBef = await asset2.totalSupply();
+            await asset2.burn(BOB, BURN_AMOUNT);
+            let totalSupplyAft = await asset2.totalSupply();
+
+            assertEq(totalSupplyBef - totalSupplyAft, BURN_AMOUNT);
+        },
+
+
+
+    };
+}

--- a/nabla/test/backstop.ts
+++ b/nabla/test/backstop.ts
@@ -42,11 +42,6 @@ export default async function (environment: TestSuiteEnvironment) {
   let swapPool1: TestContract;
   let swapPool2: TestContract;
 
-  //const asset1 = await newMockERC20("Test Token 1", "TEST1");
-  //const asset2 = await newMockERC20("Test Token 2", "TEST2");
-  //const usd = await newMockERC20("Test Backstop Token", "USD");
-
-  //WE MUST ENSURE THAT INITIAL SUPPLY IS 0
   const usd = await newTestableERC20Wrapper("Test Backstop Token", "USD", 18, [1], [1], [], []);
   const asset1 = await newTestableERC20Wrapper("TestNative", "TEST1", 18, [1], [2], [], []);
   const asset2 = await newTestableERC20Wrapper("Test Token 2", "TEST2", 18, [1], [3], [], []);

--- a/nabla/test/backstop.ts
+++ b/nabla/test/backstop.ts
@@ -43,7 +43,7 @@ export default async function (environment: TestSuiteEnvironment) {
   let swapPool2: TestContract;
 
   const usd = await newTestableERC20Wrapper("Test Backstop Token", "USD", 18, [1], [1], [], []);
-  const asset1 = await newTestableERC20Wrapper("TestNative", "TEST1", 18, [1], [2], [], []);
+  const asset1 = await newTestableERC20Wrapper("Test Token 1", "TEST1", 18, [1], [2], [], []);
   const asset2 = await newTestableERC20Wrapper("Test Token 2", "TEST2", 18, [1], [3], [], []);
 
 
@@ -120,7 +120,12 @@ export default async function (environment: TestSuiteEnvironment) {
       await backstop.addSwapPool(address(swapPool1), 0);
       await backstop.addSwapPool(address(swapPool2), 0);
 
+      //we ensure that only the MINT_AMOUNT is on the required accounts by 
+      //burning pre-existing balances.
 
+      //This is required since the assets are on the standalone testing 
+      //chain and we cannot ensure in the test alone that the balances
+      //of these tokens is indeed 0 (a test could have run earlier) 
       await asset1.burn(tester, await asset1.balanceOf(tester));
       await asset1.mint(tester, MINT_AMOUNT);
 

--- a/nabla/test/backstop.ts
+++ b/nabla/test/backstop.ts
@@ -21,6 +21,7 @@ export default async function (environment: TestSuiteEnvironment) {
       newRouter,
       newTestableBackstopPool,
       newMockERC20,
+      newTestableERC20Wrapper,
       newMockOracle,
       newNablaCurve,
       newTestableSwapPool,
@@ -41,9 +42,15 @@ export default async function (environment: TestSuiteEnvironment) {
   let swapPool1: TestContract;
   let swapPool2: TestContract;
 
-  const asset1 = await newMockERC20("Test Token 1", "TEST1");
-  const asset2 = await newMockERC20("Test Token 2", "TEST2");
-  const usd = await newMockERC20("Test Backstop Token", "USD");
+  //const asset1 = await newMockERC20("Test Token 1", "TEST1");
+  //const asset2 = await newMockERC20("Test Token 2", "TEST2");
+  //const usd = await newMockERC20("Test Backstop Token", "USD");
+
+  //WE MUST ENSURE THAT INITIAL SUPPLY IS 0
+  const usd = await newTestableERC20Wrapper("Test Backstop Token", "USD", 18, [1], [1], [], []);
+  const asset1 = await newTestableERC20Wrapper("TestNative", "TEST1", 18, [1], [2], [], []);
+  const asset2 = await newTestableERC20Wrapper("Test Token 2", "TEST2", 18, [1], [3], [], []);
+
 
   const oracleUsd = await newMockOracle(address(usd), unit(1));
   const oracle1 = await newMockOracle(address(asset1), unit(5));
@@ -118,17 +125,30 @@ export default async function (environment: TestSuiteEnvironment) {
       await backstop.addSwapPool(address(swapPool1), 0);
       await backstop.addSwapPool(address(swapPool2), 0);
 
+
+      await asset1.burn(tester, await asset1.balanceOf(tester));
       await asset1.mint(tester, MINT_AMOUNT);
+
+      await asset2.burn(tester, await asset2.balanceOf(tester));
       await asset2.mint(tester, MINT_AMOUNT);
+
+      await usd.burn(tester, await usd.balanceOf(tester));
       await usd.mint(tester, MINT_AMOUNT);
 
       vm.startPrank(BOB);
       await asset1.approve(address(swapPool1), MAX_UINT256);
       await asset2.approve(address(swapPool2), MAX_UINT256);
       await usd.approve(address(backstop), MAX_UINT256);
+
+      await asset1.burn(BOB, await asset1.balanceOf(BOB));
       await asset1.mint(BOB, MINT_AMOUNT);
+
+      await asset2.burn(BOB, await asset2.balanceOf(BOB));
       await asset2.mint(BOB, MINT_AMOUNT);
+
+      await usd.burn(BOB, await usd.balanceOf(BOB));
       await usd.mint(BOB, MINT_AMOUNT);
+
       await swapPool1.deposit(MINT_AMOUNT);
       await swapPool2.deposit(MINT_AMOUNT);
       await backstop.deposit(MINT_AMOUNT);
@@ -210,6 +230,7 @@ export default async function (environment: TestSuiteEnvironment) {
     },
 
     async testImmediateBackstopWithdrawal() {
+
       const [lpTokens, fee] = await backstop.deposit(unit(20));
       const [reservesBefore, liabilitiesBefore] = await backstop.coverage();
       const [simulatedPayout] = await backstop.simulateWithdrawal((lpTokens * 3n) / 4n);

--- a/nabla/test/swapPool.ts
+++ b/nabla/test/swapPool.ts
@@ -59,6 +59,13 @@ export default async function (environment: TestSuiteEnvironment) {
 
       // Important to deposit something before tests start, as first deposit
       // does not invoke usual _sharesToMint() logic, due to total supply being 0
+
+      //we ensure that only the MINT_AMOUNT is on the required accounts by 
+      //burning pre-existing balances.
+
+      //This is required since the assets are on the standalone testing 
+      //chain and we cannot ensure in the test alone that the balances
+      //of these tokens is indeed 0 (a test could have run earlier) 
       await asset.burn(CHARLIE, await asset.balanceOf(CHARLIE));
       await asset.mint(CHARLIE, unit(1));
 

--- a/nabla/test/swapPool.ts
+++ b/nabla/test/swapPool.ts
@@ -15,7 +15,7 @@ export default async function (environment: TestSuiteEnvironment) {
     getContractByAddress,
     vm,
     tester,
-    constructors: { newMockERC20, newNablaCurve, newTestableSwapPool },
+    constructors: { newMockERC20, newNablaCurve, newTestableSwapPool, newTestableERC20Wrapper },
   } = environment;
 
   function assertApproxEq(a: bigint, b: bigint, errorMessage: string): void {
@@ -46,17 +46,22 @@ export default async function (environment: TestSuiteEnvironment) {
   };
 
   const nablaCurve = await newNablaCurve(0, e(0.01, 18));
-  const asset = await newMockERC20("Test Token", "TEST");
+  //const asset = await newMockERC20("Test Token", "TEST");
+  const asset = await newTestableERC20Wrapper("Test Token", "TEST", 18, [1], [1], [], []);
   const pool = await newTestableSwapPool(address(asset), address(nablaCurve), 0, 0, 0, "Test LP Token", "LP");
 
   return {
     async setUp() {
       await asset.approve(address(pool), MAX_UINT256);
+
+      await asset.burn(tester, await asset.balanceOf(tester));
       await asset.mint(tester, MINT_AMOUNT);
 
       // Important to deposit something before tests start, as first deposit
       // does not invoke usual _sharesToMint() logic, due to total supply being 0
+      await asset.burn(CHARLIE, await asset.balanceOf(CHARLIE));
       await asset.mint(CHARLIE, unit(1));
+
       vm.startPrank(CHARLIE);
       await asset.approve(address(pool), unit(1));
       await pool.deposit(unit(1));

--- a/nabla/test/swapPool.ts
+++ b/nabla/test/swapPool.ts
@@ -46,7 +46,7 @@ export default async function (environment: TestSuiteEnvironment) {
   };
 
   const nablaCurve = await newNablaCurve(0, e(0.01, 18));
-  //const asset = await newMockERC20("Test Token", "TEST");
+
   const asset = await newTestableERC20Wrapper("Test Token", "TEST", 18, [1], [1], [], []);
   const pool = await newTestableSwapPool(address(asset), address(nablaCurve), 0, 0, 0, "Test LP Token", "LP");
 

--- a/nabla/test/swaps.ts
+++ b/nabla/test/swaps.ts
@@ -24,7 +24,7 @@ export default async function (environment: TestSuiteEnvironment) {
     getContractByAddress,
     vm,
     tester,
-    constructors: { newRouter, newMockERC20, newSwapPool, newMockOracle, newNablaCurve },
+    constructors: { newRouter, newMockERC20, newTestableERC20Wrapper, newSwapPool, newMockOracle, newNablaCurve },
   } = environment;
 
   function assertApproxEq(a: bigint, b: bigint, errorMessage: string): void {
@@ -94,8 +94,12 @@ export default async function (environment: TestSuiteEnvironment) {
   const router = await newRouter();
   const treasury = FERDIE;
 
-  const asset1 = await newMockERC20("Test Token 1", "TEST1");
-  const asset2 = await newMockERC20("Test Token 2", "TEST2");
+  //const asset1 = await newMockERC20("Test Token 1", "TEST1");
+  //const asset2 = await newMockERC20("Test Token 2", "TEST2");
+
+  const asset1 = await newTestableERC20Wrapper("Test Token 1", "TEST1", 18, [1], [2], [], []);
+  const asset2 = await newTestableERC20Wrapper("Test Token 2", "TEST2", 18, [1], [3], [], []);
+
   const oracle1 = await newMockOracle(address(asset1), unit(1));
   const oracle2 = await newMockOracle(address(asset2), unit(2));
 
@@ -132,8 +136,18 @@ export default async function (environment: TestSuiteEnvironment) {
       await router.registerPool(address(asset1), address(swapPool1));
       await router.registerPool(address(asset2), address(swapPool2));
 
+      await asset1.burn(tester, await asset1.balanceOf(tester));
       await asset1.mint(tester, MINT_AMOUNT);
+
+      await asset2.burn(tester, await asset2.balanceOf(tester));
       await asset2.mint(tester, MINT_AMOUNT);
+
+      await asset1.burn(treasury, await asset1.balanceOf(treasury));
+      await asset2.burn(treasury, await asset2.balanceOf(treasury));
+
+      await asset1.burn(address(swapPool1), await asset1.balanceOf(address(swapPool1)));
+
+
     },
 
     async testSwap() {

--- a/nabla/test/swaps.ts
+++ b/nabla/test/swaps.ts
@@ -124,7 +124,12 @@ export default async function (environment: TestSuiteEnvironment) {
   return {
     async setUp() {
 
-      //cleaning mock tokens in standalone chain
+      //we ensure that only the MINT_AMOUNT is on the required accounts by 
+      //burning pre-existing balances.
+
+      //This is required since the assets are on the standalone testing 
+      //chain and we cannot ensure in the test alone that the balances
+      //of these tokens is indeed 0 (a test could have run earlier) 
       await asset1.burn(tester, await asset1.balanceOf(tester));
       await asset2.burn(tester, await asset2.balanceOf(tester));
 

--- a/src/actions/compileContract.ts
+++ b/src/actions/compileContract.ts
@@ -60,7 +60,7 @@ async function actuallyCompileContract(
 
   updateContractStatus("compiling");
   const solangResult = await runCommand([
-    "/home/giannipop/root/pendulum/solang/target/release/solang",
+    "../clones/solang/target/release/solang",
     "compile",
     "--no-strength-reduce", // temporary fix for https://github.com/hyperledger/solang/issues/1507
     "--target",

--- a/src/actions/compileContract.ts
+++ b/src/actions/compileContract.ts
@@ -60,7 +60,7 @@ async function actuallyCompileContract(
 
   updateContractStatus("compiling");
   const solangResult = await runCommand([
-    "../clones/solang/target/release/solang",
+    "/home/giannipop/root/pendulum/solang/target/release/solang",
     "compile",
     "--no-strength-reduce", // temporary fix for https://github.com/hyperledger/solang/issues/1507
     "--target",


### PR DESCRIPTION
Issue: #26.

Replaced the dependency on MockERC20 for TestableERC20 contract that interacts with the standalone chain during tests.

The tests were modified accordingly to work in this manner. Specifically cleaning token balances before execution of the tests and modifying time delay for swapExecution. Also added a test specific to the TestableERC20Wrapper.

The corresponding modifications for foucococo-standalone and pendulum-wrappers for this to work were made [here](https://github.com/pendulum-chain/foucoco-standalone/pull/5) and [here](https://github.com/pendulum-chain/pendulum-ink-wrapper/pull/34) respectively.

