### PR TITLE
Add fuzz testing

### DIFF
--- a/nabla/config.json
+++ b/nabla/config.json
@@ -45,8 +45,8 @@
       "path": "contracts/src/mock/MockOracle.sol"
     },
     "VendingMachine": {
-      "path": "VendingMachine.contract",
-      "isPrecompiled": true
+      "repository": "nablaCurve",
+      "path": "test/util/VendingMachine.sol"
     }
   },
   "repositories": {
@@ -54,14 +54,11 @@
       "git": "https://github.com/0xamberhq/contracts.git",
       "branch": "feature/backstop-pool-coverage-ratio",
       "init": "yarn",
-      "importpaths": [
-        "contracts/@chain/pendulum",
-        "node_modules"
-      ]
+      "importpaths": ["contracts/@chain/pendulum", "node_modules"]
     },
     "nablaCurve": {
       "git": "https://github.com/0xamberhq/curve.git",
-      "branch": "main",
+      "branch": "3-change-slippage-curve",
       "init": "yarn"
     },
     "pendulumWrappers": {

--- a/nabla/test/nablaCurve.ts
+++ b/nabla/test/nablaCurve.ts
@@ -13,61 +13,61 @@ export default async function (environment: TestSuiteEnvironment) {
   const curve = await newNablaCurve(0, e(0.01, 18));
 
   async function calcEffectiveDeposit(reserves: bigint, liabilities: bigint, depositAmount: bigint) {
-    const potential = await curve.phi(reserves, liabilities);
-    return curve.effectiveDeposit(reserves + potential, liabilities, potential, depositAmount);
+    const reservesWithSlippage = await curve.psi(reserves, liabilities, 18);
+    return curve.inverseDiagonal(reserves, liabilities, reservesWithSlippage + depositAmount, 18);
   }
 
   return {
     async testResultingOutputMatchesPythonImpl() {
       // test_trade_in_out
-      let amm = await newVendingMachine(address(curve));
+      let amm = await newVendingMachine(address(curve), 18);
       await amm.init(e(2, 18), e(5, 18));
       assertApproxEqRel(
         await amm.totalReserves(),
         e(2.035259635368343, 18),
-        e(0.001, 18),
+        1000n,
         "test_trade_in_out accumulated slippage mismatch"
       );
       assertApproxEqRel(
         await amm.swapInto(e(1.0, 18)),
-        e(1.02435, 18),
-        e(0.01, 18),
+        e(1.02434720174884, 18),
+        1000n,
         "test_trade_in_out amount mismatch"
       );
 
       // test_trade_in_split
-      amm = await newVendingMachine(address(curve));
+      amm = await newVendingMachine(address(curve), 18);
       await amm.init(e(80, 18), e(100, 18));
       assertApproxEqRel(
         await amm.totalReserves(),
-        e(80.0439, 18),
-        e(0.001, 18),
+        e(80.04393196555968, 18),
+        1000n,
         "test_trade_in_split total reserves mismatch"
       );
       assertApproxEqRel(
         await amm.swapInto(e(100, 18)),
-        e(99.71085, 18),
-        e(0.01, 18),
+        e(99.71085396498725, 18),
+        1000n,
         "test_trade_in_split amount mismatch"
       );
 
       // test_trade_out_split
-      amm = await newVendingMachine(address(curve));
+      amm = await newVendingMachine(address(curve), 18);
       await amm.init(e(80, 18), e(100, 18));
       assertApproxEqRel(
         await amm.swapOutOf(e(30, 18)),
-        e(29.6344, 18),
-        e(0.01, 18),
+        e(29.634430721770887, 18),
+        1000n,
         "test_trade_out_split amount mismatch"
       );
 
       // test_trade_out_full
-      amm = await newVendingMachine(address(curve));
+      amm = await newVendingMachine(address(curve), 18);
       await amm.init(e(2, 18), e(5, 18));
       assertApproxEqRel(
         await amm.totalReserves(),
         e(2.035259635368343, 18),
-        e(0.001, 18),
+        1000n,
         "test_trade_out_full total reserves mismatch"
       );
       // TODO: Add assertion for swap out using exact resulting amount
@@ -77,38 +77,38 @@ export default async function (environment: TestSuiteEnvironment) {
       assertApproxEqRel(
         await calcEffectiveDeposit(e(80, 18), e(100, 18), e(10, 18)),
         e(10.004777762470999, 18),
-        e(0.001, 18),
+        1000n,
         "#1 mismatch"
       );
     },
 
     async testDepositWithdrawal() {
-      const amm = await newVendingMachine(address(curve));
+      const amm = await newVendingMachine(address(curve), 18);
       await amm.init(e(950, 18), e(1000, 18));
       assertApproxEqRel(
         await amm.totalReserves(),
         e(950.0235738135982, 18),
-        e(0.001, 18),
+        1000n,
         "test_deposit_withdraw initial total reserves mismatch"
       );
       const deposited = await amm.deposit(e(1000, 18));
-      assertApproxEqRel(deposited, e(1000.012058440754, 18), e(0.01, 18), "test_deposit_withdraw lp mismatch");
+      assertApproxEqRel(deposited, e(1000.012058440754, 18), 1000n, "test_deposit_withdraw lp mismatch");
       assertApproxEqRel(
         await amm.totalReserves(),
         e(1950.0235738135982, 18),
-        e(0.001, 18),
+        1000n,
         "test_deposit_withdraw intermediate total reserves mismatch"
       );
       assertApproxEqRel(
         await amm.withdraw(deposited),
         e(1000, 18),
-        e(0.01, 18),
+        1000n,
         "test_deposit_withdraw withdrawn amount mismatch"
       );
       assertApproxEqRel(
         await amm.totalReserves(),
         e(950.0235738135982, 18),
-        e(0.001, 18),
+        1000n,
         "test_deposit_withdraw final total reserves mismatch"
       );
     },
@@ -116,10 +116,19 @@ export default async function (environment: TestSuiteEnvironment) {
     async testNoNegativeDeposits() {
       // Regression test: (0x58788cb94b1d7fc19, 0x5b6e16f2c648b620c, 0, 0x3e8)
       assertLt(
-        await curve.effectiveDeposit(e(102, 18), e(105.41165658966665, 18), 0, e(0.0000001, 18)),
+        await curve.inverseDiagonal(e(102, 18), e(105.41165658966665, 18), e(102, 18) + e(0.0000001, 18), 18),
         2n ** 255n - 1n,
         "Regression test #1 overflow"
       );
+    },
+
+    async testDepositFuzz(deposit: bigint, deposit2: bigint) {
+      for (let decimals = 8n; decimals < 24n; decimals++) {
+        const amm = await newVendingMachine(address(curve), decimals);
+        await amm.init(2n * 10n ** decimals, 5n * 10n ** decimals);
+        await amm.deposit(deposit >> 176n);
+        await amm.swapInto(deposit2 >> 176n);
+      }
     },
   };
 }

--- a/nabla/test/nablaCurve.ts
+++ b/nabla/test/nablaCurve.ts
@@ -126,6 +126,8 @@ export default async function (environment: TestSuiteEnvironment) {
       for (let decimals = 8n; decimals < 24n; decimals++) {
         const amm = await newVendingMachine(address(curve), decimals);
         await amm.init(2n * 10n ** decimals, 5n * 10n ** decimals);
+        // we shift right by 176 bits (256 - 80) because we want both fuzz variables
+        // to be in the range 0 to 2 ** 80 - 1
         await amm.deposit(deposit >> 176n);
         await amm.swapInto(deposit2 >> 176n);
       }

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -55,10 +55,14 @@ export async function pull({ projectFolder }: PullOptions) {
 
       case "yarn": {
         console.log(`  Run yarn install`);
-        const yarnResult = await runCommand(["yarn", "install", "--ignore-engines"], { cwd: gitClonePath });
-
-        if (yarnResult.exitCode !== 0) {
-          throw new Error(`Yarn error: ${yarnResult.stdout}, ${yarnResult.stderr}`);
+        try {
+          const yarnResult = await runCommand(["yarn", "install", "--ignore-engines"], { cwd: gitClonePath });
+          if (yarnResult.exitCode !== 0) {
+            throw new Error(`Yarn error: ${yarnResult.stdout}, ${yarnResult.stderr}`);
+          }
+        } catch (error) {
+          console.error(`ERROR: There was a problem calling yarn for the repository ${repository}`);
+          console.error(error);
         }
 
         break;

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -11,6 +11,8 @@ import { SigningSubmitter, Submitter, getSubmitterAddress } from "../api/submitt
 import { PanicCode } from "@pendulum-chain/api-solang";
 import { Codec } from "@polkadot/types-codec/types";
 
+const NUMBER_OF_FUZZING_ITERATIONS = 64;
+
 export interface RunTestSuitesOptions {
   projectFolder: string;
   network: string;
@@ -389,14 +391,15 @@ async function processTestScripts(
 
         console.log(`Run test function ${test}`);
 
-        const noOfFuzzingParameters = testSuiteInstance[test].length;
-        const testIterations = noOfFuzzingParameters > 0 ? 64 * noOfFuzzingParameters : 1;
+        const numberOfFuzzingParameters = testSuiteInstance[test].length;
+        const testIterations =
+          numberOfFuzzingParameters > 0 ? NUMBER_OF_FUZZING_ITERATIONS * numberOfFuzzingParameters : 1;
         for (let iterations = 0; iterations < testIterations; iterations++) {
           const fuzzArguments = [];
 
-          if (noOfFuzzingParameters > 0) {
-            const randomNumbers = randomBytes(noOfFuzzingParameters * 32);
-            for (let i = 0; i < noOfFuzzingParameters; i++) {
+          if (numberOfFuzzingParameters > 0) {
+            const randomNumbers = randomBytes(numberOfFuzzingParameters * 32);
+            for (let i = 0; i < numberOfFuzzingParameters; i++) {
               fuzzArguments.push(BigInt(`0x${randomNumbers.subarray(i * 32, (i + 1) * 32).toString("hex")}`));
             }
             console.log(`Fuzzing with arguments`, fuzzArguments);

--- a/src/project.ts
+++ b/src/project.ts
@@ -224,7 +224,6 @@ export async function initializeProject(relativeProjectPath: string, configFileN
 
     async readTests(): Promise<{ testSuitConfig: TestSuiteConfig; testSuites: [ScriptName, TestSuite][] }> {
       const entries = await readdir(testsPath, { recursive: true, withFileTypes: true });
-      console.log(entries);
       const files: Dirent[] = entries.filter((entry) => entry.isFile());
 
       const testSuites: [string, TestSuite][] = await Promise.all(

--- a/src/project.ts
+++ b/src/project.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 import { readdir, readFile } from "node:fs/promises";
+import { Dirent } from "node:fs";
 import { prompts } from "prompts";
 import { Keyring } from "@polkadot/api";
 
@@ -223,13 +224,14 @@ export async function initializeProject(relativeProjectPath: string, configFileN
 
     async readTests(): Promise<{ testSuitConfig: TestSuiteConfig; testSuites: [ScriptName, TestSuite][] }> {
       const entries = await readdir(testsPath, { recursive: true, withFileTypes: true });
-      const fileNames = entries.filter((entry) => entry.isFile()).map((entry) => entry.name);
+      console.log(entries);
+      const files: Dirent[] = entries.filter((entry) => entry.isFile());
 
       const testSuites: [string, TestSuite][] = await Promise.all(
-        fileNames.map(async (file) => {
-          const path = join(testsPath, file);
+        files.map(async (file) => {
+          const path = join(file.path, file.name);
           const imports = (await import(path)) as TestSuite;
-          return [file, imports];
+          return [file.name, imports];
         })
       );
 

--- a/src/utils/childProcess.ts
+++ b/src/utils/childProcess.ts
@@ -30,6 +30,10 @@ export async function runCommand(
           exitCode,
         });
       });
+
+      process.on("error", (error: string) => {
+        reject(error);
+      });
     } catch (error) {
       reject(error);
     }


### PR DESCRIPTION
This PR allows to define tests with fuzzing parameters. Such tests will be executed a couple of times with random values provided for these parameters.

This PR also has the following additional changes:
* it introduces a fuzz test for the Nabla curve contract
* for this purpose it switches to the new Nabla curve contract (on branch `3-change-slippage-curve`)
* it produces better error output if some 3rd party tool (such as yarn) is not available
* it fixes a problem with test files existing in a subdirectory



Closes #31 